### PR TITLE
make ramda import only the needed functions

### DIFF
--- a/lib/add-update-subscriber.ts
+++ b/lib/add-update-subscriber.ts
@@ -1,13 +1,11 @@
-import {
-  curry,
-  map,
-  when,
-  pathEq,
-  assocPath,
-  unionWith,
-  eqBy,
-  path,
-} from 'ramda'
+import curry from 'ramda/src/curry'
+import map from 'ramda/src/map'
+import when from 'ramda/src/when'
+import pathEq from 'ramda/src/pathEq'
+import assocPath from 'ramda/src/assocPath'
+import unionWith from 'ramda/src/unionWith'
+import eqBy from 'ramda/src/eqBy'
+import path from 'ramda/src/path'
 import Sparkpost, { Recipient, UpdateRecipientList } from 'sparkpost'
 import moment from 'moment'
 import { getList } from './get-list'

--- a/lib/sanitize-text.ts
+++ b/lib/sanitize-text.ts
@@ -1,4 +1,5 @@
-import { compose, trim } from 'ramda'
+import compose from 'ramda/src/compose'
+import trim from 'ramda/src/trim'
 import sanitizeHtml from 'sanitize-html'
 
 export const sanitizeText = compose(


### PR DESCRIPTION
not sure if you have treeshaking properly set up with now.js, but you don't need to import whole ramda library, if you just need some functions... (if set up properly ignore this pr)